### PR TITLE
PERT-28: match leading zero of hours

### DIFF
--- a/src/utils/get-minutes.ts
+++ b/src/utils/get-minutes.ts
@@ -8,7 +8,7 @@
 export const getMinutes = (timeValue: string): number => {
   if (!timeValue) return 0;
 
-  const timeValueParts = [...timeValue.matchAll(/(\d+(?:\.\d+)?)+(h|m)/gi)];
+  const timeValueParts = [...timeValue.matchAll(/(\.?\d+(?:\.\d+)?)+(h|m)/gi)];
   if (timeValueParts.length) {
     // we are dealing with a hour minutes string
     const hours = timeValueParts


### PR DESCRIPTION
**Description of the proposed changes**
This PR fixes picking up decimal hour values correctly.
We were not matching the hour values with decimals earlier.

**Time tracking**
Please use Toggl time code **PERT-28: pert-with-wings Code Review**
