### PR TITLE
PERT-36: support devops new boards hub experience new experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pert-with-wings",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/PertModal/PertModal.module.css
+++ b/src/components/PertModal/PertModal.module.css
@@ -68,7 +68,7 @@
   display: block;
 }
 
-:global(body:not(:has(.witform-layout)) #pert-button-azure) {
+:global(body:not(:has([aria-label="Discussion"])) #pert-button-azure) {
   /* hide in non ticket pages in Azure Devops */
   display: none;
 }


### PR DESCRIPTION
**Description of the proposed changes**
switch the css selector for a more common selector which works in devops new boards hub experience new experience as well as old layout


**Time tracking**
Please use Toggl time code **PERT-36: PERT with Wings Code Review**
