### PR TITLE
PERT-46: allow same value for all 3 fields

### DIFF
--- a/src/components/PertRowsForm/PertRowsForm.tsx
+++ b/src/components/PertRowsForm/PertRowsForm.tsx
@@ -91,7 +91,7 @@ const PertRowsForm: FC = () => {
       return;
     }
 
-    if (optimisticMinutes >= likelyMinutes) {
+    if (optimisticMinutes > likelyMinutes) {
       updatePertMessage(
         id,
         'error',
@@ -100,7 +100,7 @@ const PertRowsForm: FC = () => {
       return;
     }
 
-    if (likelyMinutes >= pessimisticMinutes) {
+    if (likelyMinutes > pessimisticMinutes) {
       updatePertMessage(
         id,
         'error',

--- a/src/components/PertTable/PertTable.tsx
+++ b/src/components/PertTable/PertTable.tsx
@@ -108,12 +108,20 @@ const PertTable: FC<Props> = ({ forwardRef }) => {
     [pertMinutes]
   );
 
-  const isValidPert =
-    optimisticMinutes < likelyMinutes && likelyMinutes < pessimisticMinutes;
+  const isValidPert = useMemo(() => {
+    return pertRows.every(
+      (row) =>
+        row.error === '' &&
+        row.pessimistic !== '' &&
+        row.likely !== '' &&
+        row.optimistic
+    );
+  }, [pertData]);
+
   const isValidQaMinutes =
     qAExactMinutes &&
-    qAExactMinutes.optimistic < qAExactMinutes.likely &&
-    qAExactMinutes.likely < qAExactMinutes.pessimistic;
+    qAExactMinutes.optimistic <= qAExactMinutes.likely &&
+    qAExactMinutes.likely <= qAExactMinutes.pessimistic;
 
   const devTasks = pertRows.filter((row) => !row.isQATask);
 


### PR DESCRIPTION
**Description of the proposed changes**
- allow same value for all 3 fields
- This allows devs to add previous time spent as  a static row, We probably want to seek a better way to do this in the future
- we are only checking if relevent fields are not less now.

**Screenshots (if applicable)**
before 
![image](https://github.com/aligent/pert-with-wings/assets/39038569/79d52067-4340-472e-b2fc-8e8f79a9203b)

after
![image](https://github.com/aligent/pert-with-wings/assets/39038569/9e94bf48-3948-44b3-9a25-9f132fad2916)


**Other solutions considered (if any)**
_

**Notes to reviewers**
_

**Time tracking**
Please use Toggl time code **PERT-<ID>: PERT with Wings Code Review**
