### PR TITLE
PERT-51: only capitalize input text if its a placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pert-with-wings",
   "private": true,
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/PertRowsForm/PertRowsForm.module.css
+++ b/src/components/PertRowsForm/PertRowsForm.module.css
@@ -59,6 +59,9 @@
   z-index: 1;
   font-size: 1rem;
   background: var(--pert-field-bg);
+}
+
+.field::placeholder {
   text-transform: capitalize;
 }
 


### PR DESCRIPTION
**Description of the proposed changes**
only capitalize input text if its a placeholder

**Screenshots (if applicable)**
before 
![image](https://github.com/aligent/pert-with-wings/assets/39038569/78ded1df-11ce-4523-9fa1-955181b1518b)


**Other solutions considered (if any)**
_

**Notes to reviewers**
_

**Time tracking**
Please use Toggl time code **PERT-51: PERT with Wings Code Review**
